### PR TITLE
New version of conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,5 @@ RUN cd && \
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /conda && \
     rm Miniconda*.sh
-    conda install conda=4.2.12
-    conda install conda-build=2.0.12
+    conda install conda=4.3.22 -y
+    conda install conda-build=2.0.12 -y


### PR DESCRIPTION
as a test, still both -dev and -tag will go to tag. But I want to check why the new version of master branch doesn't come.