### PR TITLE
BLD: fix conda version to 4.5 to avoid issues with conda-execute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN conda config --show-sources
 RUN conda list --show-channel-urls
 RUN cat $CONDARC_PATH
 RUN conda install python=3.6 -y
-RUN conda install conda conda-build anaconda-client conda-execute conda-env conda-verify networkx slacker
+RUN conda install conda=4.5 conda-build anaconda-client conda-execute conda-env conda-verify networkx slacker
 RUN conda execute https://raw.githubusercontent.com/NSLS-II/lightsource2-recipes/master/scripts/build.py -h
 RUN conda info
 RUN conda config --show-sources

--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Check if the required DOCKER_ID_USER is set up in the env vars
-env | grep 'DOCKER_ID_USER=' || (echo 'ERROR: "DOCKER_ID_USER" must be set up in your env' && exit 1)
+# env | grep 'DOCKER_ID_USER=' || (echo 'ERROR: "DOCKER_ID_USER" must be set up in your env' && exit 1)
+DOCKER_ID_USER=nsls2
 image_name='debian-with-miniconda'
 
 timestamp="$(date +%Y%m%d%H%M%S)"
@@ -28,8 +29,8 @@ echo -e  "\nDocker images:"            >> $logfile 2>&1
 docker images | grep ${image_id}       >> $logfile 2>&1
 
 # Push the built images (requires running "docker login" before)
-docker push $DOCKER_ID_USER/${image_name}:latest       >> $logfile 2>&1
-docker push $DOCKER_ID_USER/${image_name}:${timestamp} >> $logfile 2>&1
+docker push $DOCKER_ID_USER/${image_name}:latest       >> $logfile 2>&1 || exit 1
+docker push $DOCKER_ID_USER/${image_name}:${timestamp} >> $logfile 2>&1 || exit 1
 
 # Remove timestamped tag, so that next time it's built, the existing tags are
 # not pushed to https://hub.docker.com


### PR DESCRIPTION
A new image was generated with this PR and was pushed to https://hub.docker.com/r/nsls2/debian-with-miniconda/tags/ with the following tags:
- `20190215140753` (this time-stamped label is useful to keep track of previous images)
- `latest` (matches the one above).

@leofang, it should fix the issue with conda-build 3.17.
