### PR TITLE
Fix wheezy apt sources and other improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,18 +64,6 @@ ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
-# bash-git-prompt:
-RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1
-
-# Dot files:
-RUN cd && git clone https://github.com/mrakitin/dotfiles && \
-    cp -v dotfiles/bashrc /root/.bashrc && \
-    cp -v dotfiles/vimrc /root/.vimrc && \
-    cp -v dotfiles/bash_history /root/.bash_history && \
-    rm -rfv dotfiles/
-
-ENV HISTFILE=/root/.bash_history
-
 # Add the conda binary folder to the path
 ENV PATH /conda/bin:$PATH
 
@@ -110,3 +98,18 @@ RUN conda execute https://raw.githubusercontent.com/NSLS-II/lightsource2-recipes
 RUN conda info
 RUN conda config --show-sources
 RUN conda list --show-channel-urls
+
+
+## Convenience for interactive debugging:
+
+# bash-git-prompt:
+RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1
+
+# Dot files:
+RUN cd && git clone https://github.com/mrakitin/dotfiles && \
+    cp -v dotfiles/bashrc /root/.bashrc && \
+    cp -v dotfiles/vimrc /root/.vimrc && \
+    cp -v dotfiles/bash_history /root/.bash_history && \
+    rm -rfv dotfiles/
+
+ENV HISTFILE=/root/.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN conda info
 RUN conda config --show-sources
 RUN conda list --show-channel-urls
 RUN cat $CONDARC_PATH
-RUN conda install python=3.7 -y
+RUN conda install python=3.7 ipython
 RUN conda install conda conda-build anaconda-client conda-env conda-verify networkx slacker
 RUN conda info
 RUN conda config --show-sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,17 +96,24 @@ RUN conda info
 RUN conda config --show-sources
 RUN conda list --show-channel-urls
 
+# create a user, since we don't want to run as root
+ENV USER=builder
+RUN useradd -m $USER
+ENV HOME=/home/$USER
+WORKDIR $HOME
+USER $USER
+RUN cp -v $CONDARC_PATH $HOME
 
 ## Convenience for interactive debugging:
 
 # bash-git-prompt:
-RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1
+RUN git clone https://github.com/magicmonty/bash-git-prompt.git $HOME/.bash-git-prompt --depth=1
 
 # Dot files:
 RUN cd && git clone https://github.com/mrakitin/dotfiles && \
-    cp -v dotfiles/bashrc /root/.bashrc && \
-    cp -v dotfiles/vimrc /root/.vimrc && \
-    cp -v dotfiles/bash_history /root/.bash_history && \
+    cp -v dotfiles/bashrc $HOME/.bashrc && \
+    cp -v dotfiles/vimrc $HOME/.vimrc && \
+    cp -v dotfiles/bash_history $HOME/.bash_history && \
     rm -rfv dotfiles/
 
-ENV HISTFILE=/root/.bash_history
+ENV HISTFILE=$HOME/.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,6 @@ RUN cd && git clone https://github.com/mrakitin/dotfiles && \
     cp -v dotfiles/bash_history $HOME/.bash_history && \
     rm -rfv dotfiles/
 
+RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> $HOME/.bashrc
+
 ENV HISTFILE=$HOME/.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,9 @@ ENV LC_ALL C.UTF-8
 ENV PATH /conda/bin:$PATH
 
 # Actually install miniconda
-# Miniconda 4.5.11 already has Python 3.7 as a default interpreter, so
-# we use version 4.5.4 which still uses Python 3.6
 RUN cd && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh --no-verbose && \
-    bash Miniconda3-4.5.4-Linux-x86_64.sh -b -p /conda && \
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /conda && \
     rm Miniconda*.sh
 
 ENV CONDARC_PATH /root/.condarc

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,15 +65,15 @@ ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Add the conda binary folder to the path
-ENV PATH /conda/bin:$PATH
+ENV PATH /opt/conda/bin:$PATH
 
 # Actually install miniconda
 RUN cd && \
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /conda && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda*.sh
 
-ENV CONDARC_PATH /root/.condarc
+ENV CONDARC_PATH /opt/conda/.condarc
 ENV CONDARC $CONDARC_PATH
 ENV PYTHONUNBUFFERED 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,9 +92,8 @@ RUN conda info
 RUN conda config --show-sources
 RUN conda list --show-channel-urls
 RUN cat $CONDARC_PATH
-RUN conda install python=3.6 -y
-RUN conda install conda=4.5 conda-build anaconda-client conda-execute conda-env conda-verify networkx slacker
-RUN conda execute https://raw.githubusercontent.com/NSLS-II/lightsource2-recipes/master/scripts/build.py -h
+RUN conda install python=3.7 -y
+RUN conda install conda conda-build anaconda-client conda-env conda-verify networkx slacker
 RUN conda info
 RUN conda config --show-sources
 RUN conda list --show-channel-urls

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM debian:7.9
 
 MAINTAINER Maksim Rakitin <mrakitin@bnl.gov>
 
+RUN echo "deb http://archive.debian.org/debian wheezy main\n\
+deb-src http://archive.debian.org/debian wheezy main\n\
+deb http://archive.debian.org/debian wheezy-backports main\n\
+deb-src http://archive.debian.org/debian wheezy-backports main" > /etc/apt/sources.list
+
 RUN apt-get update && \
     apt-get install -y  \
       autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ deb-src http://archive.debian.org/debian wheezy-backports main" > /etc/apt/sourc
 
 RUN apt-get update && \
     apt-get install -y  \
+      alien \
       autoconf \
       build-essential \
       bzip2 \


### PR DESCRIPTION
- Fix Wheezy apt sources
- Add `alien` converter of rpm-packages to `.deb`
- Move convenience scripts/rc files to the end of `Dockerfile`
- Install Python 3.7; remove `conda-execute`
- Use the latest miniconda distribution
- Install `conda` into /opt/conda/
- Use a user account rather than root

This update will require updating `./repo/...` --> `/repo/...` in [nsls2-tag-build.sh](https://github.com/NSLS-II/lightsource2-recipes/blob/9a243e9df581ced09430379931d4d529c34afa19/scripts/nsls2-tag-build.sh#L75) and [nsls2_tag_build.py](https://github.com/NSLS-II/lightsource2-recipes/blob/9a243e9df581ced09430379931d4d529c34afa19/scripts/nsls2_tag_build.py#L48).

Closes #15.