### PR TITLE
apt-get install libegl1-mesa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && \
       libsmbclient-dev \
       tk-dev \
       libx11-6 libx11-dev \
+      # needed by xrt (see https://github.com/NSLS-II/lightsource2-recipes/pull/676):
+      libegl1-mesa \
       # gobject-introspection
       flex \
       # install extra packages for gobject-introspection package


### PR DESCRIPTION
Needed by `xrt` (see https://github.com/NSLS-II/lightsource2-recipes/pull/676).

Successfully tested the build of `xrt` interactively after installing `libegl1-mesa` in the container:
```bash
$ docker run -it -u root --rm -v $PWD:/test nsls2/debian-with-miniconda:v0.1.0 bash
root@28de36dddce8:/test# apt-get install libegl1-mesa
conda build .
```