### PR TITLE
Fix builder permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,9 +100,10 @@ RUN conda list --show-channel-urls
 
 # create a user, since we don't want to run as root
 ENV USER=builder
-RUN useradd -m $USER
+RUN useradd -ms /bin/bash $USER
 ENV HOME=/home/$USER
 WORKDIR $HOME
+RUN chown -Rv $USER: /opt/conda/
 USER $USER
 RUN cp -v $CONDARC_PATH $HOME
 


### PR DESCRIPTION
The builder user from `debian-with-miniconda:v0.1.1` failed to install a package (https://travis-ci.org/NSLS-II/lightsource2-recipes/jobs/587940597#L461):
```
conda.CondaMultiError: [Errno 13] Permission denied: '/test/.cph_tmpih6hzrf_'
```

Locally I observed another error:
```bash
$ docker run -it --rm -v $PWD:/test nsls2/debian-with-miniconda:v0.1.1 bash -c "cd /test && conda build ."No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Attempting to finalize metadata for xrt
INFO:conda_build.metadata:Attempting to finalize metadata for xrt
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Traceback (most recent call last):
  File "/opt/conda/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 445, in main
    execute(sys.argv[1:])
  File "/opt/conda/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 436, in execute
    verify=args.verify, variants=args.variants)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/api.py", line 209, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/build.py", line 2343, in build_tree
    notest=notest,
  File "/opt/conda/lib/python3.7/site-packages/conda_build/build.py", line 1334, in build
    output_metas = expand_outputs([(m, need_source_download, need_reparse_in_env)])
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 746, in expand_outputs
    for (output_dict, m) in _m.copy().get_output_metadata_set(permit_unsatisfiable_variants=False):
  File "/opt/conda/lib/python3.7/site-packages/conda_build/metadata.py", line 2047, in get_output_metadata_set
    bypass_env_check=bypass_env_check)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/metadata.py", line 721, in finalize_outputs_pass
    permit_unsatisfiable_variants=permit_unsatisfiable_variants)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 527, in finalize_metadata
    exclude_pattern)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 390, in add_upstream_pins
    permit_unsatisfiable_variants, exclude_pattern)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 381, in _read_upstream_pin_files
    extra_run_specs = get_upstream_pins(m, actions, env)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 368, in get_upstream_pins
    run_exports = _read_specs_from_package(loc, dist)
  File "/opt/conda/lib/python3.7/site-packages/conda/exports.py", line 198, in __call__
    value = self.func(*args, **kw)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 258, in _read_specs_from_package
    specs_yaml = utils.package_has_file(pkg_loc, 'info/run_exports.yaml')
  File "/opt/conda/lib/python3.7/site-packages/conda_build/utils.py", line 1135, in package_has_file
    conda_package_handling.api.extract(package_path, cache_path, 'info')
  File "/opt/conda/lib/python3.7/site-packages/conda_package_handling/api.py", line 43, in extract
    _os.makedirs(dest_dir)
  File "/opt/conda/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/opt/conda/pkgs/gcc_linux-64-7.3.0-h553295d_8'
```
This PR should fix the issue by resolving the permissions.